### PR TITLE
Fix repository and homepage fields in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "cross-env": "^5.0.5",
     "unist-util-map": "^1.0.3"
   },
-  "homepage": "https://github.com/weknowinc/gatsby-remark-twitter#readme",
+  "homepage": "https://github.com/weknowinc/gatsby-remark-twitch#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/weknowinc/gatsby-remark-twitter.git"
+    "url": "git+https://github.com/weknowinc/gatsby-remark-twitch.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "cross-env": "^5.0.5",
     "unist-util-map": "^1.0.3"
   },
-  "homepage": "https://github.com/weknowinc/gatsby-remark-twitch#readme",
+  "homepage": "https://github.com/octahedroid/gatsby-remark-twitch#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/weknowinc/gatsby-remark-twitch.git"
+    "url": "git+https://github.com/octahedroid/gatsby-remark-twitch.git"
   }
 }


### PR DESCRIPTION
This branch updates two links in package.json to fix links from NPM and Gatsby's plugin directory to this repo.