### PR TITLE
Fix package to work with new API requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Editors
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ plugins: [
           resolve:"@weknow/gatsby-remark-twitch",
           options: {
             width: 800,
-            height: 400
+            height: 400,
+            // Required!
+            domain: 'example.com' // Also accepts "https://example.com/route
           }
         }
       ]
@@ -45,7 +47,7 @@ https://www.twitch.tv/videos/347319713
 
 #### Twitch clip
 
-https://www.twitch.tv/xisuma/clip/MagnificentOilyUdonTTours
+https://clips.twitch.tv/MagnificentOilyUdonTTours
 
 #### Twitch channel
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "cross-env": "^5.0.5",
     "unist-util-map": "^1.0.3"
   },
-  "homepage": "https://github.com/weknowinc/gatsby-remark-twitter#readme",
+  "homepage": "https://github.com/weknowinc/gatsby-remark-twitch#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/weknowinc/gatsby-remark-twitter.git"
+    "url": "git+https://github.com/weknowinc/gatsby-remark-twitch.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,6 @@
     "babel-runtime": "^6.26.0",
     "unist-util-visit": "^1.1.3"
   },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5",
-    "unist-util-map": "^1.0.3"
-  },
   "homepage": "https://github.com/octahedroid/gatsby-remark-twitch#readme",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "cross-env": "^5.0.5",
     "unist-util-map": "^1.0.3"
   },
-  "homepage": "https://github.com/weknowinc/gatsby-remark-twitch#readme",
+  "homepage": "https://github.com/octahedroid/gatsby-remark-twitch#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/weknowinc/gatsby-remark-twitch.git"
+    "url": "git+https://github.com/octahedroid/gatsby-remark-twitch.git"
   }
 }


### PR DESCRIPTION
Trying to use the package today will throw errors for two reasons:

- No `parent` query parameter, which Twitch has started enforcing
- Clips and video endpoint URLs have changed slightly

This PR enables passing the `parent` query parameter and fixing the regex commands

This PR also includes #2 to avoid merge conflicts
